### PR TITLE
Remove SSE references

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -6,7 +6,7 @@ MCP Chart Image Scanner는 MCP 서버를 실행하기 위한 Docker 이미지를
 
 - Alpine 기반 이미지
 - Helm CLI 포함
-- stdio 및 SSE 프로토콜을 지원하는 MCP 서버
+- stdio 프로토콜을 지원하는 MCP 서버
 
 ## 사용법
 
@@ -14,12 +14,6 @@ MCP Chart Image Scanner는 MCP 서버를 실행하기 위한 Docker 이미지를
 
 ```bash
 docker pull <registry>/mcp-chart-scanner:latest
-```
-
-### SSE 프로토콜로 서버 실행
-
-```bash
-docker run -p 8000:8000 <registry>/mcp-chart-scanner:latest
 ```
 
 ### stdio 프로토콜로 서버 실행
@@ -46,4 +40,4 @@ docker build -t <registry>/mcp-chart-scanner:latest .
 
 ## 포트
 
-- `8000`: SSE 프로토콜의 기본 포트
+특별한 노출 포트는 필요하지 않습니다.

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -39,9 +39,6 @@ for image in images:
 ```bash
 # stdio 프로토콜로 서버 시작
 chart-scanner-server --transport stdio
-
-# SSE 프로토콜로 서버 시작
-chart-scanner-server --transport sse --host 0.0.0.0 --port 8000
 ```
 
 ## 고급 사용법

--- a/docs/usage/advanced.md
+++ b/docs/usage/advanced.md
@@ -28,8 +28,8 @@ MCP Chart Image Scanner는 Smithery.ai 마켓플레이스와 호환됩니다. �
 from fastmcp import Client
 
 async def main():
-    # 서버에 연결
-    async with Client("http://localhost:8000/sse") as client:
+    # 서버에 연결 (stdio)
+    async with Client("chart-scanner-server") as client:
         # 사용 가능한 도구 나열
         tools = await client.list_tools()
         print(f"사용 가능한 도구: {tools}")


### PR DESCRIPTION
## Summary
- update `docs/usage` examples to only mention stdio
- remove SSE usage from Docker instructions
- update advanced usage example

## Testing
- `pytest -q` *(fails: command not found)*