### PR TITLE
Add safe extraction check

### DIFF
--- a/mcp_chart_scanner/extract.py
+++ b/mcp_chart_scanner/extract.py
@@ -37,11 +37,19 @@ def extract_chart(chart_archive: pathlib.Path, dest_dir: pathlib.Path) -> pathli
         The root directory of the extracted chart
 
     Raises:
-        RuntimeError: If the chart structure is unexpected
+        RuntimeError: If an archive member is outside ``dest_dir`` or the
+            chart structure is unexpected
     """
     logger.info(f"Extracting chart archive: {chart_archive}")
+    dest_dir_abs = dest_dir.resolve()
     with tarfile.open(chart_archive, "r:gz") as tar:
-        tar.extractall(dest_dir)
+        for member in tar.getmembers():
+            member_path = (dest_dir_abs / member.name).resolve()
+            if not member_path.is_relative_to(dest_dir_abs):
+                raise RuntimeError(
+                    f"Archive member outside destination directory: {member.name}"
+                )
+            tar.extract(member, dest_dir)
 
     roots = [p for p in dest_dir.iterdir() if p.is_dir()]
     if len(roots) != 1:

--- a/tests/test_extract_chart.py
+++ b/tests/test_extract_chart.py
@@ -1,0 +1,22 @@
+import io
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from mcp_chart_scanner.extract import extract_chart
+
+
+def test_extract_chart_rejects_outside_members(tmp_path):
+    tar_path = tmp_path / "evil.tgz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        data = b"malicious"
+        info = tarfile.TarInfo(name="../evil.txt")
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+
+    dest_dir = tmp_path / "dest"
+    dest_dir.mkdir()
+
+    with pytest.raises(RuntimeError):
+        extract_chart(tar_path, dest_dir)


### PR DESCRIPTION
## Summary
- validate tar member paths before extraction
- test extracting tarballs with path traversal raises an error
- clarify docstring and use `tar.extract(member, dest_dir)`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*