### PR TITLE
Fix get_usage return

### DIFF
--- a/mcp_chart_scanner/server/mcp_server.py
+++ b/mcp_chart_scanner/server/mcp_server.py
@@ -106,7 +106,7 @@ mcp = FastMCP("Chart Image Scanner")
 @mcp.resource("help://usage")
 def get_usage() -> str:
     """Get usage information."""
-    return """
+    usage = """
     # Chart Image Scanner
 
     This tool extracts Docker images from Helm charts. It supports multiple chart sources:
@@ -137,6 +137,7 @@ def get_usage() -> str:
         print(f"Error: {e}")
     ```
     """
+    return usage
 
 
 @mcp.tool()

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,0 +1,7 @@
+from mcp_chart_scanner.server.mcp_server import get_usage
+
+
+def test_get_usage_not_empty():
+    usage = get_usage()
+    assert isinstance(usage, str)
+    assert usage.strip() != ""


### PR DESCRIPTION
## Summary
- refactor get_usage to build usage text via a variable
- add a unit test to ensure usage text is not empty

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*