### PR TITLE
Add safe extraction check

### DIFF
--- a/tests/test_extract_chart.py
+++ b/tests/test_extract_chart.py
@@ -1,0 +1,21 @@
+import io
+import tarfile
+
+import pytest
+
+from mcp_chart_scanner.extract import extract_chart
+
+
+def test_extract_chart_rejects_outside_members(tmp_path):
+    tar_path = tmp_path / "evil.tgz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        data = b"malicious"
+        info = tarfile.TarInfo(name="../evil.txt")
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+
+    dest_dir = tmp_path / "dest"
+    dest_dir.mkdir()
+
+    with pytest.raises(RuntimeError):
+        extract_chart(tar_path, dest_dir)


### PR DESCRIPTION
## Summary
- validate tar member paths before extraction
- test extracting tarballs with path traversal raises an error
- remove unused `Path` import in tests

## Testing
- `python -m flake8 mcp_chart_scanner tests --max-line-length=120` *(fails: No module named flake8)*
- `python -m pytest -q` *(fails: No module named pytest)*