### PR TITLE
Update README with Cursor instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ source venv/bin/activate
 pip install -e .
 ```
 
+설치가 완료되면 아래와 같이 `.cursor.json` 파일에 MCP 서버를 등록해 사용할 수 있습니다.
+
+```json
+{
+  "mcpServers": {
+    "chart-scanner": {
+      "command": "chart-scanner-server",
+      "args": ["--transport", "stdio"]
+    }
+  }
+}
+```
+
 ### Using Docker
 
 ```bash


### PR DESCRIPTION
## Summary
- add guidance on registering MCP server in `.cursor.json`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*