### PR TITLE
docs: clarify Helm CLI requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ cd mcp-chart-image-scanner
 pipx install -e .
 ```
 
+> **필수**: 이 패키지에는 Helm CLI가 포함되어 있지 않습니다. 사용 전에 Helm CLI를 별도로 설치해야 합니다.
+
 > **주의**: 반드시 루트 디렉토리(`mcp-chart-image-scanner/`)에서 설치해야 합니다. 하위 디렉토리(`mcp_chart_scanner/`)에서 설치하면 실패합니다.
 >
 > **참고**: 일부 시스템에서는 "externally-managed-environment" 오류가 발생할 수 있습니다. 이 경우 가상 환경을 생성하거나 `--break-system-packages` 옵션을 사용하세요.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -5,7 +5,7 @@ MCP Chart Image Scanner는 MCP 서버를 실행하기 위한 Docker 이미지를
 ## 특징
 
 - Alpine 기반 이미지
-- Helm CLI 포함
+- Helm CLI 필요(이미지에 포함되지 않음)
 - stdio 프로토콜을 지원하는 MCP 서버
 
 ## 사용법


### PR DESCRIPTION
## Summary
- clarify that Helm CLI must be installed separately in installation docs
- update Docker documentation to state that Helm CLI is required

## Testing
- `pytest -q` *(fails: command not found)*