### PR TITLE
Implement helm CLI checks in CLI

### DIFF
--- a/mcp_chart_scanner/cli.py
+++ b/mcp_chart_scanner/cli.py
@@ -7,6 +7,11 @@ import pathlib
 import sys
 
 from mcp_chart_scanner.extract import extract_images_from_chart
+from mcp_chart_scanner.server.mcp_server import (
+    ERROR_HELM_INSTALL_GUIDE,
+    ERROR_HELM_NOT_INSTALLED,
+    check_helm_cli,
+)
 
 
 def parse_cli_args() -> argparse.Namespace:
@@ -49,6 +54,12 @@ def main() -> None:
 
     if args.quiet:
         logging.getLogger().setLevel(logging.ERROR)
+
+    if not check_helm_cli():
+        print(ERROR_HELM_NOT_INSTALLED)
+        print(ERROR_HELM_INSTALL_GUIDE)
+        sys.exit(1)
+        return
 
     try:
         images = extract_images_from_chart(

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -1,0 +1,39 @@
+import pathlib
+from unittest import mock
+
+from mcp_chart_scanner.cli import main
+from mcp_chart_scanner.server.mcp_server import (
+    ERROR_HELM_INSTALL_GUIDE,
+    ERROR_HELM_NOT_INSTALLED,
+)
+
+
+@mock.patch("mcp_chart_scanner.cli.extract_images_from_chart")
+@mock.patch("mcp_chart_scanner.cli.check_helm_cli")
+@mock.patch("mcp_chart_scanner.cli.parse_cli_args")
+def test_cli_main_helm_cli_not_installed(
+    mock_parse_args, mock_check_helm_cli, mock_extract_images
+):
+    args = mock.MagicMock()
+    args.chart = pathlib.Path("chart.tgz")
+    args.values = []
+    args.quiet = False
+    args.json = False
+    args.raw = False
+    mock_parse_args.return_value = args
+    mock_check_helm_cli.return_value = False
+
+    with (
+        mock.patch("sys.exit") as mock_exit,
+        mock.patch("builtins.print") as mock_print,
+    ):
+        main()
+        mock_check_helm_cli.assert_called_once()
+        mock_print.assert_has_calls(
+            [
+                mock.call(ERROR_HELM_NOT_INSTALLED),
+                mock.call(ERROR_HELM_INSTALL_GUIDE),
+            ]
+        )
+        mock_exit.assert_called_once_with(1)
+    mock_extract_images.assert_not_called()


### PR DESCRIPTION
## Summary
- reuse `check_helm_cli` in CLI
- exit with same messages when helm is missing
- test CLI behaviour when helm is not installed

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*