### PR TITLE
Add unified installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,41 +11,7 @@ A tool for extracting Docker image references from Helm charts with CLI and MCP 
   - Local file paths
   - Remote URLs
 - Support for stdio communication protocol
-
-## Installation
-
-### From Source
-
-```bash
-git clone https://github.com/cagojeiger/mcp-chart-image-scanner.git
-cd mcp-chart-image-scanner
-pipx install -e .
-```
-
-> **필수**: 이 패키지에는 Helm CLI가 포함되어 있지 않습니다. 사용 전에 Helm CLI를 별도로 설치해야 합니다.
-
-> **주의**: 반드시 루트 디렉토리(`mcp-chart-image-scanner/`)에서 설치해야 합니다. 하위 디렉토리(`mcp_chart_scanner/`)에서 설치하면 실패합니다.
->
-> **참고**: 일부 시스템에서는 "externally-managed-environment" 오류가 발생할 수 있습니다. 이 경우 가상 환경을 생성하거나 `--break-system-packages` 옵션을 사용하세요.
-```bash
-python -m venv venv
-source venv/bin/activate
-pip install -e .
-```
-
-설치가 완료되면 아래와 같이 `.cursor.json` 파일에 MCP 서버를 등록해 사용할 수 있습니다.
-
-```json
-{
-  "mcpServers": {
-    "chart-scanner": {
-      "command": "chart-scanner-server",
-      "args": ["--transport", "stdio"]
-    }
-  }
-}
-```
-
+자세한 설치 방법은 [설치 가이드](./docs/installation.md)를 참조하세요.
 
 ## Usage
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,22 +2,8 @@
 
 MCP Chart Image Scanner는 Helm 차트에서 Docker 이미지를 추출하기 위한 명령줄 인터페이스를 제공합니다.
 
-## 설치
+설치 방법은 [설치 가이드](./installation.md)를 참조하세요.
 
-```bash
-git clone https://github.com/cagojeiger/mcp-chart-image-scanner.git
-cd mcp-chart-image-scanner
-pipx install -e .
-```
-
-> **주의**: 반드시 루트 디렉토리(`mcp-chart-image-scanner/`)에서 설치해야 합니다. 하위 디렉토리(`mcp_chart_scanner/`)에서 설치하면 실패합니다.
->
-> **참고**: 일부 시스템에서는 "externally-managed-environment" 오류가 발생할 수 있습니다. 이 경우 가상 환경을 생성하거나 `--break-system-packages` 옵션을 사용하세요.
-```bash
-python -m venv venv
-source venv/bin/activate
-pip install -e .
-```
 
 ## 사용법
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,43 @@
+# 설치 가이드
+
+이 문서는 MCP Chart Image Scanner의 설치 방법을 설명합니다.
+
+## 기본 설치
+
+1. 저장소를 클론합니다.
+   ```bash
+   git clone https://github.com/cagojeiger/mcp-chart-image-scanner.git
+   cd mcp-chart-image-scanner
+   ```
+2. `pipx`를 사용하여 설치합니다.
+   ```bash
+   pipx install -e .
+   ```
+
+   가상 환경을 이용하려면 다음과 같이 실행합니다.
+   ```bash
+   python -m venv venv
+   source venv/bin/activate
+   pip install -e .
+   ```
+
+### 필수 조건
+
+- Helm CLI가 포함되어 있지 않으므로 별도로 설치해야 합니다.
+- 반드시 프로젝트 루트 디렉토리(`mcp-chart-image-scanner/`)에서 설치해야 합니다.
+- 일부 시스템에서 `externally-managed-environment` 오류가 발생할 경우 가상 환경을 생성하거나 `pip install -e . --break-system-packages` 옵션을 사용합니다.
+
+## Cursor 연동
+
+설치 후 Cursor에서 MCP 서버를 사용하려면 `.cursor.json` 파일에 다음과 같이 등록합니다.
+
+```json
+{
+  "mcpServers": {
+    "chart-scanner": {
+      "command": "chart-scanner-server",
+      "args": ["--transport", "stdio"]
+    }
+  }
+}
+```

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -20,28 +20,11 @@ MCP 서버는 Helm 차트에서 Docker 이미지를 추출하는 도구를 MCP �
 - 차트 형식 검증: Chart.yaml 파일이 없는 경우, 유효하지 않은 tarball 형식 등
 - Helm CLI 검증: Helm CLI가 설치되어 있지 않은 경우
 - 임시 파일 관리: 임시 파일 생성 및 작업 완료 후 자동 정리
-
-## 설치
-
-```bash
-git clone https://github.com/cagojeiger/mcp-chart-image-scanner.git
-cd mcp-chart-image-scanner
-pipx install -e .
-```
-
-> **주의**: 반드시 루트 디렉토리(`mcp-chart-image-scanner/`)에서 설치해야 합니다. 하위 디렉토리(`mcp_chart_scanner/`)에서 설치하면 실패합니다.
->
-> **참고**: 일부 시스템에서는 "externally-managed-environment" 오류가 발생할 수 있습니다. 이 경우 가상 환경을 생성하거나 `--break-system-packages` 옵션을 사용하세요.
-```bash
-python -m venv venv
-source venv/bin/activate
-pip install -e .
-```
+설치 방법은 [설치 가이드](./installation.md)를 참조하세요.
 
 ## 서버 시작하기
 
 ### stdio 프로토콜
-
 ```bash
 chart-scanner-server --transport stdio
 ```


### PR DESCRIPTION
## Summary
- document installation steps under `docs/installation.md`
- link to installation guide from README, CLI doc and server doc
- remove duplicated installation sections

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*