### PR TITLE
Add setup make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: help setup
+
+help: ## 명령어 목록을 출력합니다.
+@grep -E '^[a-zA-Z_-]+:.*?## .+' Makefile | awk 'BEGIN {FS=":.*?## "}; {printf "%-15s %s\n", $$1, $$2}'
+
+setup: ## 개발 의존성을 설치합니다.
+@if [ -f poetry.lock ] || grep -q "\[tool.poetry\]" pyproject.toml 2>/dev/null; then \
+poetry install; \
+else \
+pip install -e .[dev]; \
+fi

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ chart-scanner-server --transport stdio
 
 
 
+## Local Development
+
+개발 의존성은 다음 명령으로 설치합니다.
+
+```bash
+make setup
+```
+
 ## Documentation
 
 For a brief introduction, see the [Quick Start guide](./docs/quickstart.md).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -21,6 +21,18 @@
    pip install -e .
    ```
 
+개발 의존성까지 한 번에 설치하려면 다음 명령을 사용합니다.
+
+```bash
+make setup
+```
+
+Poetry를 사용한다면 대신 다음 명령을 실행합니다.
+
+```bash
+poetry install
+```
+
 ### 필수 조건
 
 - Helm CLI가 포함되어 있지 않으므로 별도로 설치해야 합니다.


### PR DESCRIPTION
## Summary
- add `setup` command to install dev dependencies
- document `make setup` usage in README
- document development setup in install guide

## Testing
- `pytest` *(fails: command not found)*